### PR TITLE
Fix VideoProcessingThread threshold initialization

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -19,7 +19,7 @@ class VideoProcessingThread(QThread):
     def __init__(self, processor, mode='process', green_boxes=None, red_boxes=None):
         super().__init__()
         self.processor = processor
-        self.threshold = threshold
+        self.threshold = processor.threshold_value
         self.mode = mode
         self.green_boxes = green_boxes
         self.red_boxes = red_boxes


### PR DESCRIPTION
## Summary
- ensure thread uses the processor's threshold value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed7f3f29c832dbda9a4afed7af547