### PR TITLE
Move VideoProcessingThread into its own module

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -4,29 +4,10 @@ import cv2
 
 from Result import ResultWindow
 from PyQt5.QtWidgets import QSizePolicy, QApplication, QMainWindow, QFileDialog, QLabel, QSlider, QPushButton, QWidget, QVBoxLayout, QHBoxLayout, QTextEdit, QProgressBar
-from PyQt5.QtCore import Qt, QThread, pyqtSignal, QTimer
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtGui import QPixmap, QImage
 import video_processing
-
-class VideoProcessingThread(QThread):
-    finished = pyqtSignal(object)
-    progress = pyqtSignal(int)
-
-    def __init__(self, processor, mode='process', green_boxes=None, red_boxes=None):
-        super().__init__()
-        self.processor = processor
-        self.mode = mode
-        self.green_boxes = green_boxes
-        self.red_boxes = red_boxes
-
-    def run(self):
-        if self.mode == 'preprocess':
-            result_image = self.processor.preprocess_all_frames()
-        else:
-            self.processor.preprocess_all_frames()
-            result_image = self.processor.process_with_squares(self.green_boxes, self.red_boxes)
-
-        self.finished.emit(result_image)
+from video_thread import VideoProcessingThread
 
 class CustodianApp(QMainWindow):
     DEFAULT_PREVIEW_WIDTH = 720

--- a/video_thread.py
+++ b/video_thread.py
@@ -1,0 +1,24 @@
+from PyQt5.QtCore import QThread, pyqtSignal
+
+
+class VideoProcessingThread(QThread):
+    """Run video processing operations in a separate thread."""
+
+    finished = pyqtSignal(object)
+    progress = pyqtSignal(int)
+
+    def __init__(self, processor, mode='process', green_boxes=None, red_boxes=None):
+        super().__init__()
+        self.processor = processor
+        self.mode = mode
+        self.green_boxes = green_boxes
+        self.red_boxes = red_boxes
+
+    def run(self):
+        if self.mode == 'preprocess':
+            result_image = self.processor.preprocess_all_frames()
+        else:
+            self.processor.preprocess_all_frames()
+            result_image = self.processor.process_with_squares(self.green_boxes, self.red_boxes)
+
+        self.finished.emit(result_image)


### PR DESCRIPTION
## Summary
- move `VideoProcessingThread` from `gui.py` into new `video_thread.py`
- import `VideoProcessingThread` from the new module in `gui.py`

## Testing
- `pip install numpy opencv-python-headless PyQt5 pytest sympy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4e44b7f4832d858c247883fd1612