### PR TITLE
Fix typo and add video loading test

### DIFF
--- a/Result.py
+++ b/Result.py
@@ -87,7 +87,7 @@ class ResultWindow(QWidget):
         self.label.setPixmap(pixmap)
         self.label.adjustSize()
 
-        # resize window to mathc image size
+        # resize window to match image size
         self.resize(image_width, image_height)
 
 

--- a/tests/test_video_loading.py
+++ b/tests/test_video_loading.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+
+# Ensure project root is on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from video_processing import VideoProcessor
+
+
+def test_load_video_raises_for_invalid_path(tmp_path):
+    """VideoProcessor.load_video should raise an error for bad paths."""
+    bad_path = tmp_path / "nonexistent.mp4"
+    proc = VideoProcessor(str(bad_path), threshold_value=10, preview_label=None)
+    with pytest.raises((ValueError, IOError)):
+        proc.load_video()
+

--- a/video_processing.py
+++ b/video_processing.py
@@ -123,6 +123,9 @@ class VideoProcessor:
         return fast_positions, [], frame
 
     def update_preview(self, frame):
+        if self.preview_label is None:
+            return
+
         rgb_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         height, width, channel = rgb_frame.shape
         bytes_per_line = 3 * width


### PR DESCRIPTION
## Summary
- fix typo in comment in `Result.py`
- handle missing preview label in `VideoProcessor.update_preview`
- add a unit test covering invalid path behavior in `VideoProcessor.load_video`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed61f9e8c832d8186ae3b62d9e75c