### PR TITLE
Fix off by one in final object assembly

### DIFF
--- a/video_processing.py
+++ b/video_processing.py
@@ -66,7 +66,7 @@ class VideoProcessor:
         final_image = self.frames[0].copy()
 
         #for i in range(len(self.frames) -1):
-        for i, frame_positions in enumerate(self.all_positions):
+        for i, frame_positions in enumerate(self.all_positions, start=1):
             current_frame = self.frames[i].copy()
             #temp_image = final_image.copy()
 


### PR DESCRIPTION
## Summary
- correct frame index when composing final image so detected object slices match their original frame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532fda1780832d8ee5869cedf399eb