### PR TITLE
Add eraser to GUI for removing detection boxes

### DIFF
--- a/tests/test_video_processing.py
+++ b/tests/test_video_processing.py
@@ -93,3 +93,20 @@ def test_load_video_valid_sample(tmp_path):
     assert len(proc.frames) == 3
 
     video_file.unlink()
+
+
+def test_remove_boxes_at_removes_box():
+    frame1 = make_frame_with_rect((2, 2), (5, 5), size=(20, 20))
+    frame2 = make_frame_with_rect((5, 2), (8, 5), size=(20, 20))
+    proc = DummyProcessor(None, threshold_value=5, preview_label=None)
+    proc.min_speed = 1
+    proc.max_size = 200
+    proc.frames = [frame1, frame2]
+    proc.all_positions = [[(2, 2, 3, 3)], []]
+    proc.preprocessed_frames = [frame1.copy()]
+
+    original_count = sum(len(p) for p in proc.all_positions)
+    proc.remove_boxes_at(2, 2)
+    new_count = sum(len(p) for p in proc.all_positions)
+    assert new_count == original_count - 1
+

--- a/video_processing.py
+++ b/video_processing.py
@@ -199,3 +199,30 @@ class VideoProcessor:
 
     def create_background_subtractor(self):
         self.fgbg = cv2.createBackgroundSubtractorMOG2(history=500, varThreshold=self.threshold_value, detectShadows=False)
+
+    def render_preprocessed_preview(self):
+        """Recreate the first frame with all current boxes."""
+        frame = self.frames[0].copy()
+        for positions in self.all_positions:
+            self.draw_boxes(frame, positions)
+        return frame
+
+    def remove_boxes_at(self, x, y):
+        """Remove any bounding box containing the given coordinates."""
+        removed = False
+        for positions in self.all_positions:
+            for box in positions[:]:
+                bx, by, bw, bh = box
+                if bx <= x <= bx + bw and by <= y <= by + bh:
+                    positions.remove(box)
+                    removed = True
+
+        if removed:
+            updated = self.render_preprocessed_preview()
+            if self.preprocessed_frames:
+                self.preprocessed_frames[0] = updated
+            else:
+                self.preprocessed_frames = [updated]
+            if self.preview_label is not None:
+                self.update_preview(updated)
+


### PR DESCRIPTION
## Summary
- add `EraserLabel` widget to intercept clicks for removing boxes
- provide eraser button and related methods in GUI
- update `VideoProcessor` with methods to remove boxes and rerender preview
- test `remove_boxes_at` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685334060150832da5680c1c1b0c4c56