### PR TITLE
Enable drag eraser

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -28,6 +28,17 @@ class EraserLabel(QLabel):
             return
         super().mousePressEvent(event)
 
+    def mouseMoveEvent(self, event):
+        if (
+            self.parent_window
+            and getattr(self.parent_window, "eraser_mode", False)
+            and (event.buttons() & Qt.LeftButton)
+        ):
+            self.parent_window.handle_eraser_click(event.pos().x(), event.pos().y())
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
 class CustodianApp(QMainWindow):
     DEFAULT_PREVIEW_WIDTH = 720
     DEFAULT_PREVIEW_HEIGHT = 405  # 16:9 aspect ratio

--- a/tests/test_eraser_label.py
+++ b/tests/test_eraser_label.py
@@ -1,0 +1,38 @@
+import os
+import sys
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PyQt5.QtWidgets import QApplication, QWidget
+from PyQt5.QtCore import Qt, QPoint
+from PyQt5.QtGui import QMouseEvent
+
+# Ensure the project root is on the Python path so gui can be imported
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gui import EraserLabel
+
+
+def test_mouse_move_calls_parent_handle():
+    app = QApplication.instance() or QApplication([])
+
+    class DummyParent(QWidget):
+        def __init__(self):
+            super().__init__()
+            self.called = []
+            self.eraser_mode = True
+
+        def handle_eraser_click(self, x, y):
+            self.called.append((x, y))
+
+    parent = DummyParent()
+    label = EraserLabel(parent)
+
+    event = QMouseEvent(
+        QMouseEvent.MouseMove,
+        QPoint(5, 7),
+        Qt.LeftButton,
+        Qt.LeftButton,
+        Qt.NoModifier,
+    )
+
+    label.mouseMoveEvent(event)
+    assert parent.called == [(5, 7)]


### PR DESCRIPTION
## Summary
- extend `EraserLabel` with `mouseMoveEvent` so dragging erases continuously
- test the new eraser behaviour when moving the mouse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853486da320832d805aece2bf839fc1