### PR TITLE
Improve eraser feedback

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -5,7 +5,7 @@ import cv2
 from Result import ResultWindow
 from PyQt5.QtWidgets import QSizePolicy, QApplication, QMainWindow, QFileDialog, QLabel, QSlider, QPushButton, QWidget, QVBoxLayout, QHBoxLayout, QTextEdit, QProgressBar
 from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QPixmap, QImage
+from PyQt5.QtGui import QPixmap, QImage, QPainter, QPen, QColor
 import video_processing
 from video_thread import VideoProcessingThread
 
@@ -16,6 +16,9 @@ class EraserLabel(QLabel):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.parent_window = parent
+        self.setMouseTracking(True)
+        self._erasing = False
+        self._cursor_pos = None
 
     def mousePressEvent(self, event):
         if (
@@ -23,10 +26,51 @@ class EraserLabel(QLabel):
             and getattr(self.parent_window, "eraser_mode", False)
             and event.button() == Qt.LeftButton
         ):
-            self.parent_window.handle_eraser_click(event.pos().x(), event.pos().y())
+            self._erasing = True
+            self._cursor_pos = event.pos()
+            self.parent_window.handle_eraser_click(self._cursor_pos.x(), self._cursor_pos.y())
+            self.update()
             event.accept()
             return
         super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if self.parent_window and getattr(self.parent_window, "eraser_mode", False):
+            self._cursor_pos = event.pos()
+            if self._erasing and (event.buttons() & Qt.LeftButton):
+                self.parent_window.handle_eraser_click(self._cursor_pos.x(), self._cursor_pos.y())
+                event.accept()
+                self.update()
+                return
+            self.update()
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._erasing = False
+        self._cursor_pos = event.pos()
+        self.update()
+        super().mouseReleaseEvent(event)
+
+    def leaveEvent(self, event):
+        self._cursor_pos = None
+        self.update()
+        super().leaveEvent(event)
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        if (
+            self.parent_window
+            and getattr(self.parent_window, "eraser_mode", False)
+            and self._cursor_pos is not None
+        ):
+            radius = self.parent_window.eraser_radius_in_label()
+            painter = QPainter(self)
+            pen = QPen(QColor(255, 0, 0))
+            pen.setWidth(1)
+            painter.setPen(pen)
+            painter.drawEllipse(self._cursor_pos, radius, radius)
+            painter.end()
 
 class CustodianApp(QMainWindow):
     DEFAULT_PREVIEW_WIDTH = 720
@@ -56,6 +100,8 @@ class CustodianApp(QMainWindow):
         self.slider_timer.setSingleShot(True)
         self.slider_timer.timeout.connect(self.process_slider_change)
         self.eraser_mode = False
+        self.eraser_radius = 10
+        self.cancel_button = None
 
         self.initUI()
 
@@ -108,6 +154,13 @@ class CustodianApp(QMainWindow):
         self.eraser_button.setEnabled(False)
         button_layout.addWidget(self.eraser_button)
 
+        # Cancel button
+        self.cancel_button = QPushButton('Cancel', self)
+        self.cancel_button.clicked.connect(self.cancel_processing)
+        self.cancel_button.setFixedHeight(40)
+        self.cancel_button.setEnabled(False)
+        button_layout.addWidget(self.cancel_button)
+
         button_layout.addStretch(1)
         button_and_preview_layout.addLayout(button_layout)
         main_layout.addLayout(button_and_preview_layout)
@@ -157,6 +210,16 @@ class CustodianApp(QMainWindow):
         #self.threshold_label.setFixedHeight(20)
         sliders_layout.addWidget(self.max_size_slider)
 
+        # Eraser radius label and slider
+        self.eraser_radius_label = QLabel(f'Eraser Radius: {self.eraser_radius}', self)
+        sliders_layout.addWidget(self.eraser_radius_label)
+        self.eraser_radius_slider = QSlider(Qt.Horizontal, self)
+        self.eraser_radius_slider.setMinimum(1)
+        self.eraser_radius_slider.setMaximum(100)
+        self.eraser_radius_slider.setValue(self.eraser_radius)
+        self.eraser_radius_slider.valueChanged.connect(self.update_eraser_radius)
+        sliders_layout.addWidget(self.eraser_radius_slider)
+
         # Add info text panel to display print statements
         self.info_text_panel = QTextEdit(self)
         self.info_text_panel.setReadOnly(True)  # Make it read-only
@@ -167,7 +230,7 @@ class CustodianApp(QMainWindow):
         self.progress_bar = QProgressBar(self)
         sliders_layout.addWidget(self.progress_bar)
 
-        sliders_container.setFixedHeight(250)
+        sliders_container.setFixedHeight(300)
         main_layout.addWidget(sliders_container)
 
         self.show()
@@ -265,10 +328,16 @@ class CustodianApp(QMainWindow):
             self.display_frame(self.current_frame_index)
             self.slider_timer.start(300)
 
+    def update_eraser_radius(self, value):
+        self.eraser_radius = value
+        self.eraser_radius_label.setText(f'Eraser Radius: {value}')
+        self.video_preview_label.update()
+
     def toggle_eraser(self):
         self.eraser_mode = self.eraser_button.isChecked()
         state = "On" if self.eraser_mode else "Off"
         self.eraser_button.setText(f"Eraser: {state}")
+        self.video_preview_label.update()
 
     def label_to_frame_coordinates(self, x, y):
         if not self.processor or not self.processor.frames:
@@ -285,10 +354,19 @@ class CustodianApp(QMainWindow):
         frame_y = max(0, min(frame_h - 1, frame_y))
         return frame_x, frame_y
 
+    def eraser_radius_in_label(self):
+        if not self.processor or not self.processor.frames:
+            return self.eraser_radius
+        frame_h, frame_w = self.processor.frames[0].shape[:2]
+        label_w = self.video_preview_label.width()
+        label_h = self.video_preview_label.height()
+        scale = min(label_w / frame_w, label_h / frame_h)
+        return max(1, int(self.eraser_radius * scale))
+
     def handle_eraser_click(self, x, y):
         fx, fy = self.label_to_frame_coordinates(x, y)
         if self.processor:
-            self.processor.remove_boxes_at(fx, fy)
+            self.processor.remove_boxes_at(fx, fy, self.eraser_radius)
 
     def process_slider_change(self):
         print("slider changed - preprocess_video called")
@@ -326,7 +404,13 @@ class CustodianApp(QMainWindow):
         self.processor.progress_signal = self.thread.progress
         self.thread.progress.connect(self.progress_bar.setValue)
         self.thread.finished.connect(self.on_processing_finished)
+        self.thread.finished.connect(lambda: self.cancel_button.setEnabled(False))
+        self.cancel_button.setEnabled(True)
         self.thread.start()
+
+    def cancel_processing(self):
+        if self.thread and self.thread.isRunning():
+            self.thread.requestInterruption()
 
     def on_processing_finished(self, result_images):
         if self.thread.mode == 'preprocess':

--- a/tests/test_video_processing.py
+++ b/tests/test_video_processing.py
@@ -106,7 +106,7 @@ def test_remove_boxes_at_removes_box():
     proc.preprocessed_frames = [frame1.copy()]
 
     original_count = sum(len(p) for p in proc.all_positions)
-    proc.remove_boxes_at(2, 2)
+    proc.remove_boxes_at(2, 2, radius=0)
     new_count = sum(len(p) for p in proc.all_positions)
     assert new_count == original_count - 1
 
@@ -120,6 +120,52 @@ def test_remove_boxes_at_updates_preview():
     proc.all_positions = [[(2, 2, 3, 3)]]
     proc.preprocessed_frames = [frame.copy()]
 
-    proc.remove_boxes_at(3, 3)
+    proc.remove_boxes_at(3, 3, radius=0)
     assert hasattr(proc, "preview_updated") and proc.preview_updated
+
+
+def test_remove_boxes_at_respects_radius():
+    frame = make_frame_with_rect((0, 0), (15, 15), size=(20, 20))
+    proc = DummyProcessor(None, threshold_value=5, preview_label=object())
+    proc.frames = [frame]
+    proc.all_positions = [[(2, 2, 3, 3), (7, 2, 3, 3)]]
+    proc.preprocessed_frames = [frame.copy()]
+
+    proc.remove_boxes_at(5, 3, radius=5)
+    assert all(len(p) == 0 for p in proc.all_positions)
+    assert hasattr(proc, "preview_updated") and proc.preview_updated
+
+
+def test_preprocess_all_frames_can_cancel():
+    frame1 = make_frame_with_rect((2, 2), (5, 5), size=(20, 20))
+    frame2 = make_frame_with_rect((5, 2), (8, 5), size=(20, 20))
+    frame3 = make_frame_with_rect((8, 2), (11, 5), size=(20, 20))
+    proc = DummyProcessor(None, threshold_value=5, preview_label=object())
+    proc.min_speed = 1
+    proc.max_size = 200
+    proc.frames = [frame1, frame2, frame3]
+
+    called = 0
+
+    def should_cancel():
+        nonlocal called
+        called += 1
+        return called > 1
+
+    proc.preprocess_all_frames(should_cancel=should_cancel)
+    assert len(proc.all_positions) == 1
+    assert hasattr(proc, "preview_updated")
+
+
+def test_process_with_squares_can_cancel():
+    frame1 = make_frame_with_rect((2, 2), (5, 5), size=(20, 20))
+    frame2 = make_frame_with_rect((5, 2), (8, 5), size=(20, 20))
+    proc = DummyProcessor(None, threshold_value=5, preview_label=None)
+    proc.min_speed = 1
+    proc.max_size = 200
+    proc.frames = [frame1, frame2]
+    proc.preprocess_all_frames()
+
+    result = proc.process_with_squares(should_cancel=lambda: True)[0]
+    assert np.array_equal(result, frame1)
 

--- a/video_processing.py
+++ b/video_processing.py
@@ -6,12 +6,13 @@ from PyQt5.QtWidgets import QApplication
 
 class VideoProcessor:
 
-    def __init__( self, video_path, threshold_value, preview_label, progress_signal = None):
+    def __init__(self, video_path, threshold_value, preview_label, progress_signal=None, verbose=False):
         self.prev_fast_positions = []
         self.video_path = video_path
         self.threshold_value = threshold_value
         self.preview_label = preview_label
         self.progress_signal = progress_signal
+        self.verbose = verbose
         self.frames = []
         self.min_speed = 750
         self.max_size = 150
@@ -20,7 +21,8 @@ class VideoProcessor:
         self.fgbg = cv2.createBackgroundSubtractorMOG2(history=500, varThreshold=threshold_value, detectShadows=False)
 
     def load_video(self):
-        print(f"Loading video from: {self.video_path}")
+        if self.verbose:
+            print(f"Loading video from: {self.video_path}")
         if not isinstance(self.video_path, str) or not self.video_path:
             raise ValueError("Invalid video path provided")
 
@@ -37,7 +39,8 @@ class VideoProcessor:
         cap.release()
         if not self.frames:
             raise ValueError("No frames were loaded from the video. Check the file format or codec.")
-        print(f"Loaded {len(self.frames)} frames successfully.")
+        if self.verbose:
+            print(f"Loaded {len(self.frames)} frames successfully.")
 
     def extract_object_region(self, frame, x, y, w, h):
         """
@@ -59,7 +62,7 @@ class VideoProcessor:
             return cv2.bitwise_and(frame[y:y + h, x:x + w], frame[y:y + h, x:x + w], mask=mask[:, :, None])
         return None
 
-    def process_with_squares(self, green_boxes=None, red_boxes=None):
+    def process_with_squares(self, green_boxes=None, red_boxes=None, should_cancel=None):
         """
         Processes all detected objects across frames and combines them into the final image.
         """
@@ -67,6 +70,8 @@ class VideoProcessor:
 
         # for each recorded frame's positions start from the second frame
         for i, frame_positions in enumerate(self.all_positions):
+            if should_cancel and should_cancel():
+                break
             current_frame = self.frames[i].copy()
             #temp_image = final_image.copy()
 
@@ -96,7 +101,8 @@ class VideoProcessor:
         # Detect contours for both fast and slow movers
         contours_fast, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
-        print(f"Contours detected (fast): {len(contours_fast)}")
+        if self.verbose:
+            print(f"Contours detected (fast): {len(contours_fast)}")
 
         fast_positions = []
         #slow_positions = []
@@ -105,7 +111,8 @@ class VideoProcessor:
         for i, contour in enumerate(contours_fast):
             area = cv2.contourArea(contour)
             if 5 < area < self.max_size:  # Ensure reasonable area range
-                print(f"Fast contour area: {area}, max size: {self.max_size}")
+                if self.verbose:
+                    print(f"Fast contour area: {area}, max size: {self.max_size}")
                 x, y, w, h = cv2.boundingRect(contour)
                 current_fast_positions.append(((x + w / 2, y + h / 2), (w, h), i))  # Store center and dimensions
 
@@ -115,7 +122,8 @@ class VideoProcessor:
                 for prev_cx, prev_cy in self.prev_fast_positions:
                     speed = np.linalg.norm(np.array([cx, cy]) - np.array([prev_cx, prev_cy]))
                     if speed > self.min_speed:
-                        print(f"Object speed: {speed}, min speed: {self.min_speed}")
+                        if self.verbose:
+                            print(f"Object speed: {speed}, min speed: {self.min_speed}")
                         x, y, w, h = cv2.boundingRect(contours_fast[i])
                         fast_positions.append((x, y, w, h))
         self.prev_fast_positions = [pos[0] for pos in current_fast_positions] # update positions for next frame
@@ -131,7 +139,8 @@ class VideoProcessor:
 
         # Scale the pixmap to fit the label size while maintaining aspect ratio
         scaled_pixmap = pixmap.scaled(self.preview_label.size(), Qt.KeepAspectRatio, Qt.SmoothTransformation)
-        print(f"Label size: {self.preview_label.size().width()}x{self.preview_label.size().height()}")
+        if self.verbose:
+            print(f"Label size: {self.preview_label.size().width()}x{self.preview_label.size().height()}")
 
         self.preview_label.setPixmap(scaled_pixmap)
         QApplication.processEvents()
@@ -141,23 +150,28 @@ class VideoProcessor:
         fast_positions, _, _ = self.detect_fast_objects(frame, prev_frame)
 
         filtered_fast = fast_positions
-        print(f"Filtered fast objects: {len(filtered_fast)}")
+        if self.verbose:
+            print(f"Filtered fast objects: {len(filtered_fast)}")
         return filtered_fast
 
     def draw_boxes(self, frame, boxes):
         """Draw green rectangles around detected objects on the frame."""
         for (x, y, w, h) in boxes:
-            print(f"Drawing fast box at: x={x}, y={y}, w={w}, h={h}")
+            if self.verbose:
+                print(f"Drawing fast box at: x={x}, y={y}, w={w}, h={h}")
             cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 255, 0), 2)
 
-    def preprocess_all_frames(self):
+    def preprocess_all_frames(self, should_cancel=None):
         self.preprocessed_frames = []
         self.all_positions = []
         frame_count = len(self.frames)
         frame_0 = self.frames[0].copy()  # Start with the first frame
 
         for i in range(1, frame_count):
-            print(f"Processing frame {i}/{frame_count}")
+            if should_cancel and should_cancel():
+                break
+            if self.verbose:
+                print(f"Processing frame {i}/{frame_count}")
             self.create_background_subtractor()
             frame = self.frames[i].copy()
             prev_frame = self.frames[i-1].copy() if i > 0 else None
@@ -171,9 +185,10 @@ class VideoProcessor:
                 self.progress_signal.emit(progress)
 
         self.preprocessed_frames.append(frame_0)
-        print("Preprocessing completed.")
-        print(f"Frames after preprocessing: {len(self.frames)}")
-        print(f"Preprocessed frames: {len(self.preprocessed_frames)}")
+        if self.verbose:
+            print("Preprocessing completed.")
+            print(f"Frames after preprocessing: {len(self.frames)}")
+            print(f"Preprocessed frames: {len(self.preprocessed_frames)}")
         self.update_preview(frame_0)
         return self.preprocessed_frames
 
@@ -207,13 +222,15 @@ class VideoProcessor:
             self.draw_boxes(frame, positions)
         return frame
 
-    def remove_boxes_at(self, x, y):
-        """Remove any bounding box containing the given coordinates."""
+    def remove_boxes_at(self, x, y, radius=0):
+        """Remove any bounding box intersecting the circle centred at (x, y)."""
         removed = False
         for positions in self.all_positions:
             for box in positions[:]:
                 bx, by, bw, bh = box
-                if bx <= x <= bx + bw and by <= y <= by + bh:
+                dx = max(bx - x, 0, x - (bx + bw))
+                dy = max(by - y, 0, y - (by + bh))
+                if dx * dx + dy * dy <= radius * radius:
                     positions.remove(box)
                     removed = True
 

--- a/video_thread.py
+++ b/video_thread.py
@@ -15,10 +15,10 @@ class VideoProcessingThread(QThread):
         self.red_boxes = red_boxes
 
     def run(self):
+        cancel = self.isInterruptionRequested
         if self.mode == 'preprocess':
-            result_image = self.processor.preprocess_all_frames()
+            result_image = self.processor.preprocess_all_frames(should_cancel=cancel)
         else:
-            self.processor.preprocess_all_frames()
-            result_image = self.processor.process_with_squares(self.green_boxes, self.red_boxes)
+            result_image = self.processor.process_with_squares(self.green_boxes, self.red_boxes, should_cancel=cancel)
 
         self.finished.emit(result_image)


### PR DESCRIPTION
## Summary
- show eraser circle around the cursor
- refresh overlay when radius or mode changes
- make debug printing optional so erasing is smooth
- allow cancelling preprocessing or processing

## Testing
- `pip install numpy opencv-python-headless PyQt5 sympy pytest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853486da320832d805aece2bf839fc1